### PR TITLE
fix link

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
 											<a href="https://github.com/ffauchille/js-meetup-lu-chatbot" class="special">Slides</a>
 										</article>
 										<article>
-											<a href="https://rawgit.com/GrosSacASac/DOM99/master/documentation/presentation/reveal.js-2.6.2/test/examples/dom99.html#/" class="image"><img src="pres_thumb/dom99_CWa.png" alt="dom99" /></a>
+											<a href="https://dom99.now.sh/presentation/reveal.js-2.6.2/test/examples/dom99" class="image"><img src="pres_thumb/dom99_CWa.png" alt="dom99" /></a>
 											<h3 class="major">dom99</h3>
 											<p>by <a href="https://github.com/GrosSacASac">Cyril Walle</a> / September 2018</p>
 											<a href="https://rawgit.com/GrosSacASac/DOM99/master/documentation/presentation/reveal.js-2.6.2/test/examples/dom99.html#/" class="special">Slides</a>


### PR DESCRIPTION
Hi, quick fix of the link,

As you can see on this post https://rawgit.com/ is shutting down
So I moved the website to now.sh instead,
here's a PR to avoid having broken link in the future