### PR TITLE
Store slides data in JSON file and render using EJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea
 
 *.iml
+
+/node_modules

--- a/README.md
+++ b/README.md
@@ -2,3 +2,26 @@
 
 This is the source code of the website **luxembourgjs.com**. 
 No frameworks, just pure and simple html with some js and some css.
+
+Install
+- 
+
+````bash
+npm install
+````
+
+Build
+- 
+
+````bash
+npm run build
+````
+
+This generates an `index.html` using `ejs` from `data/pres-data.json` file
+
+How to add slides
+-
+
+- Add your slides to the JSON file `data/pres-data.json`
+- `npm run build`
+- make a pull request (or push to master if you have the rights)

--- a/build.js
+++ b/build.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+const ejs = require('ejs');
+const fs = require('fs');
+
+const data = require('./data/pres-data.json');
+
+console.log('Start build...\n');
+
+const htmlTemplate = fs.readFileSync('index.ejs.html', 'utf-8');
+
+const htmlContent = ejs.render(htmlTemplate, data);
+
+fs.writeFileSync('index.html', htmlContent, 'utf-8');
+
+console.log('Build done successfully\n');

--- a/data/pres-data.json
+++ b/data/pres-data.json
@@ -1,0 +1,258 @@
+{
+  "slides": [{
+    "link": "https://docs.google.com/presentation/d/16_yZG-Z4wuVkluaAuSvo0d4qaJcBcy6BEuSH71JRivY/edit?usp=sharing",
+    "thumb": "pres_thumb/workbox_VSa.png",
+    "title": "Creating powerful offline experiences with Workbox",
+    "date": "October 2019",
+    "authors": [{
+      "name": "Sam Vloeberghs",
+      "link": "https://twitter.com/samvloeberghs"
+    }]
+  }, {
+    "link": "http://lekzd.ru/presentations/webgl_simple_luxembourg/",
+    "thumb": "pres_thumb/webgl_AKo.png",
+    "title": "WebGL and 2D: simple as Web",
+    "date": "June 2019",
+    "authors": [{
+      "name": "Aleksandr Korotaev",
+      "link": "https://github.com/lekzd"
+    }]
+  }, {
+    "link": "https://docs.google.com/presentation/d/1BHJRpiEWq1mIz6uIgV8D2mVGxJ33LNVDHDVT_hwsqx4/edit",
+    "thumb": "pres_thumb/accessibility_in_practice.png",
+    "title": "Accessibility in practice",
+    "date": "June 2019",
+    "authors": [{
+      "name": "Marie Baudy",
+      "link": "https://twitter.com/pttmary"
+    }, {
+      "name": "Artur Spulnik"
+    }]
+  }, {
+    "link": "https://github.com/kawan16/nest-heroes/raw/master/Meetup%20Javascript%20Luxembourg%20-%20Nest.pdf",
+    "thumb": "pres_thumb/nest_DKa.png",
+    "title": "Nest - A Progressive Node.js Framework",
+    "date": "May 2019",
+    "authors": [{
+      "name": "Karl Devooght",
+      "link": "https://github.com/kawan16"
+    }]
+  }, {
+    "link": "https://www.slideshare.net/CrowChick/vue-in-motion",
+    "thumb": "pres_thumb/vue_in_motion_NRa.png",
+    "title": "Vue in Motion",
+    "date": "April 2019",
+    "authors": [{
+      "name": "Rachel Nabors",
+      "link": "http://rachelnabors.com/"
+    }]
+  }, {
+    "link": "pres/intro_vue.pdf",
+    "thumb": "pres_thumb/intro_vue_BSa.png",
+    "title": "Intro to Vue.js",
+    "date": "April 2019",
+    "authors": [{
+      "name": "Sami Boudrai"
+    }]
+  }, {
+    "link": "https://stephaniewalter.design/blog/lightning-fast-ux-faking-performance-when-theres-no-code-left-to-optimize/",
+    "thumb": "pres_thumb/lightning_fast_ux_SWa.jpg",
+    "title": "Lightning fast UX: faking performance when there’s no code left to optimize",
+    "date": "March 2019",
+    "authors": [{
+      "name": "Stéphanie Walter",
+      "link": "https://twitter.com/walterstephanie"
+    }]
+  }, {
+    "link": "pres/webperf_2019.pptx",
+    "thumb": "pres_thumb/web_perf_2019_JEv.png",
+    "title": "Web Performance in 2019",
+    "date": "March 2019",
+    "authors": [{
+      "name": "Jean-pierre Vincent",
+      "link": "https://twitter.com/theystolemynick"
+    }]
+  }, {
+    "link": "https://krampstudio.com/offline-webapp-talk/",
+    "thumb": "pres_thumb/offline-web-app_XYZ.png",
+    "title": "Offline Web Apps",
+    "date": "February 2019",
+    "authors": [{
+      "name": "Bertrand Chevrier",
+      "link": "https://twitter.com/kramp"
+    }]
+  }, {
+    "link": "https://stephaniewalter.design/blog/super-secret-powers-of-mobile-browsers-talk-slides/",
+    "thumb": "pres_thumb/mobile_browsers_SWa.png",
+    "title": "Super Secret Powers of Mobile Browsers",
+    "date": "January 2019",
+    "authors": [{
+      "name": "Stéphanie Walter",
+      "link": "https://twitter.com/walterstephanie"
+    }]
+  }, {
+    "link": "https://docs.google.com/presentation/d/1HCeTpKv6lCXCGJFtkRFoVbkmd_C5-Ggv4h4JlxHyaXQ/edit#slide=id.g45f10dffa6_0_0",
+    "thumb": "pres_thumb/typescript_GMo.png",
+    "title": "Typescript: tips and best practices",
+    "date": "December 2018",
+    "authors": [{
+      "name": "Guillaume Monnet",
+      "link": "https://twitter.com/255kb"
+    }, {
+      "name": "Thomas Winckell",
+      "link": "https://github.com/thomaswinckell"
+    }]
+  }, {
+    "link": "https://www.slideshare.net/vasilikaklimova/webgl-practical-application",
+    "thumb": "pres_thumb/webgl_VKl.png",
+    "title": "WebGL Practical application",
+    "date": "December 2018",
+    "authors": [{
+      "name": "Vasilika Klimova",
+      "link": "https://twitter.com/lik04ka"
+    }]
+  }, {
+    "link": "https://slides.com/nicolasfrizzarin/angular-element/fullscreen",
+    "thumb": "pres_thumb/angular_element_NFr.png",
+    "title": "Angular Element",
+    "date": "November 2018",
+    "authors": [{
+      "name": "Nicolas Frizzarin",
+      "link": "https://twitter.com/Nicooss54"
+    }]
+  }, {
+    "link": "pres/devops_SBo.pdf",
+    "thumb": "pres_thumb/devops_SBo.png",
+    "title": "Deploy fast and well",
+    "date": "November 2018",
+    "authors": [{
+      "name": "Sami Boudrai"
+    }]
+  }, {
+    "link": "https://docs.google.com/presentation/d/1lhDgVUUWlqhN6ZbWL1Dad0QUwcxPV8zMHp9ssRohZxA/edit?usp=sharing",
+    "thumb": "pres_thumb/mockoon_GUm.png",
+    "title": "Mockoon",
+    "date": "October 2018",
+    "authors": [{
+      "name": "Guillaume Monnet",
+      "link": "https://twitter.com/255kb"
+    }]
+  }, {
+    "link": "https://becoming.lu/about",
+    "thumb": "pres_thumb/becominglu_ROm.png",
+    "title": "Becoming.lu",
+    "date": "October 2018",
+    "authors": [{
+      "name": "Rodislav Moldovan",
+      "link": "https://bitbucket.org/rodislav"
+    }]
+  }, {
+    "link": "https://github.com/ffauchille/js-meetup-lu-chatbot",
+    "thumb": "pres_thumb/chatbot_FFa.png",
+    "title": "Building chatbots without Cloud",
+    "date": "September 2018",
+    "authors": [{
+      "name": "Florent Fauchille",
+      "link": "https://github.com/ffauchille"
+    }]
+  }, {
+    "link": "https://dom99.now.sh/presentation/reveal.js-2.6.2/test/examples/dom99",
+    "thumb": "pres_thumb/dom99_CWa.png",
+    "title": "dom99",
+    "date": "September 2018",
+    "authors": [{
+      "name": "Cyril Walle",
+      "link": "https://github.com/GrosSacASac"
+    }]
+  }, {
+    "link": "https://speakerdeck.com/littleiffel/reflections-on-operating-a-serverless-api",
+    "thumb": "pres_thumb/serverless_TNi.jpg",
+    "title": "On Serverless - Using Serverless in Production",
+    "date": "June 2018",
+    "authors": [{
+      "name": "Thierry Nicola",
+      "link": "https://twitter.com/littleiffel"
+    }]
+  }, {
+    "link": "https://www.dropbox.com/s/gwayo9hn7vfv2q1/CSS-Variables.pdf?dl=0",
+    "thumb": "pres_thumb/css_variables_GCr.jpg",
+    "title": "CSS Variables in the real life",
+    "date": "May 2018",
+    "authors": [{
+      "name": "Geoffrey Crofte",
+      "link": "https://twitter.com/geoffrey_crofte"
+    }]
+  }, {
+    "link": "https://slides.com/alainvagner/deck#/",
+    "thumb": "pres_thumb/accessibility_101_AVa.jpg",
+    "title": "Accessibility 101",
+    "date": "May 2018",
+    "authors": [{
+      "name": "Alain Vagner",
+      "link": "https://twitter.com/biou"
+    }]
+  }, {
+    "link": "https://github.com/ou2s/slides/raw/master/JSMeetup%20Luxembourg%20-%2003042018/JSMeetup_RN_in_Production.pdf",
+    "thumb": "pres_thumb/react_native_OGh.jpg",
+    "title": "React Native in production",
+    "date": "April 2018",
+    "authors": [{
+      "name": "Oussama Ghalbzouri",
+      "link": "https://github.com/ou2s"
+    }]
+  }, {
+    "link": "https://github.com/GrosSacASac/JavaScript-Set-Up/tree/master/general/html-streaming",
+    "thumb": "pres_thumb/html_streaming_CWa.jpg",
+    "title": "HTML Streaming",
+    "date": "April 2018",
+    "authors": [{
+      "name": "Cyril Walle",
+      "link": "https://github.com/GrosSacASac/"
+    }]
+  }, {
+    "link": "https://github.com/anton-kabysh/flowtype-experiments",
+    "thumb": "pres_thumb/flow_type_AKa.jpg",
+    "title": "Let your types Flow. Pragmatic introduction to Flowtype",
+    "date": "March 2018",
+    "authors": [{
+      "name": "Anton Kabysh",
+      "link": "https://github.com/anton-kabysh"
+    }]
+  }, {
+    "link": "https://docs.google.com/presentation/d/1E8Cz1QX6nLKzG7Vul9bX8hby9u22iT3k2gByCnBHcyM/edit?usp=sharing",
+    "thumb": "pres_thumb/ionic_ASp.jpg",
+    "title": "IONIC 3 from scratch to store",
+    "date": "February 2018",
+    "authors": [{
+      "name": "Arthur Spitznagel",
+      "link": "https://twitter.com/arthurspitznage"
+    }]
+  }, {
+    "link": "https://github.com/Algar/JSLuxembourg-February2018-VisualRegressionTesting",
+    "thumb": "pres_thumb/visual_regression_AGa.jpg",
+    "title": "Visual regression testing",
+    "date": "February 2018",
+    "authors": [{
+      "name": "Alfonso Garcia",
+      "link": "https://www.yotako.io"
+    }]
+  }, {
+    "link": "https://docs.google.com/presentation/d/10dvXKYrEZ_H8MElw6Cdpd4u5COBpJPlquT6Kf2o9iNs/edit?usp=sharing",
+    "thumb": "pres_thumb/graphql_TNi.jpg",
+    "title": "What the QL? Introduction to GraphQL.",
+    "date": "January 2018",
+    "authors": [{
+      "name": "Thierry Nicola",
+      "link": "https://twitter.com/littleiffel"
+    }]
+  }, {
+    "link": "https://js-mf.github.io/",
+    "thumb": "pres_thumb/jsmf_JSo.jpg",
+    "title": "The JavaScript Way of Model-Driven Engineering",
+    "date": "January 2018",
+    "authors": [{
+      "name": "Jean-Sébastien Sottet",
+      "link": "https://twitter.com/reversal_js"
+    }]
+  }]
+}

--- a/index.ejs.html
+++ b/index.ejs.html
@@ -197,7 +197,7 @@
           <section class="features">
             <% slides.forEach(function(slide){ %>
               <article>
-                <a href="<%= slide.link %>" class="image">
+                <a href="<%= slide.link %>" rel="nofollow" class="image">
                   <img src="<%= slide.thumb %>" alt="<%= slide.title %>" />
                 </a>
                 <h3 class="major"><%= slide.title %></h3>
@@ -206,11 +206,11 @@
                     if(!author.link) {
                       return author.name;
                     }
-                    return '<a href="' + author.link + '">' + author.name + '</a>';
+                    return '<a href="' + author.link + '" rel="nofollow">' + author.name + '</a>';
                   }).join(' & '); %>
                   / <%= slide.date %>
                 </p>
-                <a href="<%= slide.link %>" class="special">Slides</a>
+                <a href="<%= slide.link %>" class="special" rel="nofollow">Slides</a>
               </article>
             <% }); %>
           </section>

--- a/index.ejs.html
+++ b/index.ejs.html
@@ -1,0 +1,374 @@
+<!DOCTYPE HTML>
+<!--
+	Solid State by HTML5 UP
+	html5up.net | @ajlkn
+	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+-->
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>LuxembourgJS Meetup</title>
+  <meta name="description"
+    content="The finest JavaScript User Group in Luxembourg - Meeting the first Wednesday of each month">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="theme/assets/css/main.css" />
+  <noscript>
+    <link rel="stylesheet" href="theme/assets/css/noscript.css" /></noscript>
+  <style>
+    #banner .logo img {
+      width: 200px;
+      height: 200px;
+    }
+
+    .meetup_widget {
+      background-color: #f6c347;
+      color: black;
+      border-radius: 6px;
+      margin-left: 20px;
+      padding: 10px;
+      text-align: left;
+      font-size: 83%;
+      width: 350px;
+    }
+
+    #m_date {
+      font-size: 120%;
+      font-weight: bold;
+    }
+
+    #m_link a {
+      color: black;
+      font-weight: bold;
+      font-size: 110%;
+      border-bottom: dotted 1px black;
+    }
+
+    #m_nr_going {
+      font-size: 90%;
+    }
+
+    .twitter-timeline {
+      margin-right: 30px;
+    }
+
+    body.jslu {
+      background-image: linear-gradient(to top, rgba(46, 49, 65, 0.8), rgba(46, 49, 65, 0.8)), url("img/bg.jpg");
+    }
+
+    .jslu .gitter-open-chat-button {
+      background-color: #f6c347;
+      color: black;
+      font-weight: bold;
+    }
+
+    .jslu .gitter-open-chat-button {
+      background-color: #f6c347;
+      color: black;
+      font-weight: bold;
+    }
+
+    .jslu.is-preload .gitter-open-chat-button {
+      opacity: 0;
+    }
+
+    @media screen and (max-width: 480px) {
+      .meetup_widget {
+        margin-left: 0;
+        margin-bottom: 40px;
+        width: 100%;
+
+      }
+    }
+  </style>
+  <script>
+    // get data from meetup.com API
+    function updateEvent(response) {
+      let next = response.data.next_event;
+      let date = new Date(next.time);
+      document.getElementById("m_date").innerHTML = date.toLocaleString('en-UK');
+      document.getElementById("m_link").innerHTML = `<a href="https://www.meetup.com/luxembourgjs/events/${next.id}/">${next.name.replace("JavaScript Meetup Luxembourg", "")}</a>`
+      document.getElementById("m_nr_going").innerHTML = next.yes_rsvp_count;
+    }
+
+
+
+    function ready(fn) {
+      if (document.readyState != 'loading') {
+        fn();
+      } else {
+        document.addEventListener('DOMContentLoaded', fn);
+      }
+    }
+
+    ready(function () {
+      // JSONP because meetup.com does not know about CORS headers...
+      let script = document.createElement('script');
+      script.src = 'https://api.meetup.com/luxembourgjs?&sign=true&callback=updateEvent&photo-host=public&fields=next_event';
+      document.body.appendChild(script);
+    })
+
+
+  </script>
+</head>
+
+<body class="is-preload jslu">
+
+  <!-- Page Wrapper -->
+  <div id="page-wrapper">
+
+
+    <!-- Gitter "Open Chat" button -->
+    <!-- Customise here https://sidecar.gitter.im/ -->
+    <script>
+        ((window.gitter = {}).chat = {}).options = {
+        room: 'js-luxembourg/Lobby'
+      };
+    </script>
+    <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+
+
+    <!-- Banner -->
+    <section id="banner">
+      <div class="inner">
+        <div class="logo"><img src="img/jslu-logo.jpg" alt="LuxembourgJS"></div>
+        <h1>LuxembourgJS</h1>
+        <p>The finest JavaScript User Group in Luxembourg</p>
+      </div>
+    </section>
+
+    <!-- Wrapper -->
+    <section id="wrapper">
+
+      <!-- One -->
+      <section id="one" class="wrapper spotlight style1">
+        <div class="inner">
+          <div class="meetup_widget">
+            Next meetup:<br />
+            <span id="m_date"></span><br />
+            <span id="m_link"></span><br />
+            <span id="m_nr_going"></span> people going
+          </div>
+          <div class="content">
+            <h2 class="major">When is the next event?</h2>
+            <p>We usually have one event per month, the first wednesday of the month. Each event is announced on
+              meetup.com., where we kindly ask you to RSVP for organisational reasons. The location of the event changes
+              regularly, so be sure to check the event page on meetup.com for more details. </p>
+            <a href="https://www.meetup.com/luxembourgjs/" class="special">LuxembourgJS on Meetup.com</a>
+          </div>
+        </div>
+      </section>
+
+      <!-- Two -->
+      <section id="two" class="wrapper alt spotlight style2">
+        <div class="inner">
+          <a class="twitter-timeline" data-lang="en" data-width="450" data-height="300" data-dnt="true"
+            data-theme="dark" data-link-color="#2B7BB9"
+            href="https://twitter.com/luxembourgjs?ref_src=twsrc%5Etfw">Tweets by LuxembourgJS</a>
+          <script async src="https://platform.twitter.com/widgets.js"></script>
+          <div class="content">
+            <h2 class="major">How can I stay informed?</h2>
+            <p>We have Twitter and Facebook accounts managed by our members.</p>
+            <a href="https://twitter.com/luxembourgjs" class="special">Follow us on Twitter</a>
+            <a href="https://www.facebook.com/groups/luxembourgjs/" class="special">Follow us on Facebook</a>
+          </div>
+        </div>
+      </section>
+
+      <!-- Three -->
+      <section id="three" class="wrapper spotlight style3">
+        <div class="inner">
+          <a href="https://gitter.im/js-luxembourg" class="image"><img src="img/gitter.svg" alt="gitter" /></a>
+          <div class="content">
+            <h2 class="major">How can I stay in touch with the community?</h2>
+            <p>We are currently switching to Gitter. Gitter is simple, you can log in with your Twitter, Github or
+              Gitlab account and join our room! To join us, click on the following link or on the "open&nbsp;chat"
+              button at the bottom right of this website.</p>
+            <a href="https://gitter.im/js-luxembourg" class="special">Join our Gitter room</a>
+          </div>
+        </div>
+      </section>
+
+      <!-- Four -->
+      <section id="four" class="wrapper alt style1">
+        <div class="inner">
+          <h2 class="major" id="slides">Last talks &amp; slides</h2>
+          <p>You can find here the slides from the latest talks that have been given during our meetups.</p>
+          <section class="features">
+            <% slides.forEach(function(slide){ %>
+              <article>
+                <a href="<%= slide.link %>" class="image">
+                  <img src="<%= slide.thumb %>" alt="<%= slide.title %>" />
+                </a>
+                <h3 class="major"><%= slide.title %></h3>
+                <p>by
+                  <%- slide.authors.map(function(author){
+                    if(!author.link) {
+                      return author.name;
+                    }
+                    return '<a href="' + author.link + '">' + author.name + '</a>';
+                  }).join(' & '); %>
+                  / <%= slide.date %>
+                </p>
+                <a href="<%= slide.link %>" class="special">Slides</a>
+              </article>
+            <% }); %>
+          </section>
+        </div>
+      </section>
+
+      <!-- Three -->
+      <section id="five" class="wrapper style2">
+        <div class="inner">
+          <div class="content" id="codeofconduct">
+            <h2 class="major">Code of Conduct</h2>
+            <p>All attendees, speakers, sponsors and volunteers at our meetup are required to agree with the following
+              code of conduct. Organisers will enforce this code throughout the event. We expect cooperation from all
+              participants to help ensure a safe environment for everybody.</p>
+
+            <h3>The Quick Version</h3>
+            <p>Our meetup is dedicated to providing a harassment-free experience for everyone, regardless of gender,
+              gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race,
+              ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of meetup
+              participants in any form. Sexual language and imagery is not appropriate for any meetup venue, including
+              talks, networking, social events, Twitter and other online media. Meetup participants violating these
+              rules may be sanctioned or expelled from the meetup at the discretion of the meetup organisers.</p>
+
+            <h3>The Less Quick Version</h3>
+            <h4>Purpose</h4>
+
+            <p>A primary goal of LuxembourgJS is to be inclusive to the largest number of contributors, with the most
+              varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and
+              welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic
+              status, and religion (or lack thereof).
+              This code of conduct outlines our expectations for all those who participate in our community, as well as
+              the consequences for unacceptable behavior. We will also apply those rules for the selection of speakers,
+              sponsors, and venues.
+              We invite all those who participate in LuxembourgJS to help us create a safe and positive experience for
+              everyone.</p>
+
+            <h4>Unacceptable behavior</h4>
+            <p>The following behaviors are considered harassment and are unacceptable within our community:</p>
+            <ul>
+              <li>Discriminatory jokes and language related to gender, gender identity and expression, age, sexual
+                orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or
+                technology choices.</li>
+              <li>Posting or displaying sexually explicit or violent material.</li>
+              <li>Violence, threats of violence or violent language directed against another person.</li>
+              <li>Posting or threatening to post other people’s personally identifying information ("doxing").</li>
+              <li>Personal insults, particularly those related to gender, sexual orientation, race, religion, or
+                disability.</li>
+              <li>Inappropriate photography or recording.</li>
+              <li>Inappropriate physical contact. You should have someone’s consent before touching them.</li>
+              <li>Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching,
+                groping, and unwelcomed sexual advances. Our meetups are not dating events.</li>
+              <li>Deliberate intimidation, stalking or following (online or in person).</li>
+              <li>Advocating for, or encouraging, any of the above behavior.</li>
+              <li>Sustained disruption of community events, including talks and presentations.</li>
+            </ul>
+
+            <h4>Consequences of Unacceptable Behavior</h4>
+            <p>Unacceptable behavior from any community member, including sponsors and those with decision-making
+              authority, will not be tolerated.
+              Anyone asked to stop unacceptable behavior is expected to comply immediately.
+              If a participant engages in harassing behavior, the meetup organisers may take any action they deem
+              appropriate, up to and including a temporary ban or permanent expulsion from the community without
+              warning.</p>
+
+            <h4>Reporting an incident</h4>
+            <p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please
+              contact one of the meetup organisers immediately. </p>
+
+            <p>
+              <a href="https://www.meetup.com/luxembourgjs/members/?op=leaders">Contact the organisation team</a>
+            </p>
+            <p>
+              The organisation team will be happy to help participants contact venue security or local law enforcement,
+              provide escorts, or otherwise assist those experiencing harassment to feel safe during the meetups. </p>
+
+            <h4>Addressing Grievances</h4>
+            <p>If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should
+              notify <a href="https://www.meetup.com/luxembourgjs/members/?op=leaders">the organisation team</a> with a
+              concise description of your grievance. Your grievance will be handled in accordance with our existing
+              governing policies.</p>
+            <h4>Scope</h4>
+            <p>We expect all participants (attendees; sponsors; speakers; hosts; and other guests) to abide by this Code
+              of Conduct in all community venues–online and in-person–as well as in all one-on-one communications
+              pertaining to community business.
+              This code of conduct and its related procedures also applies to unacceptable behavior occurring outside
+              the scope of community activities when such behavior has the potential to adversely affect the safety and
+              well-being of community members.</p>
+
+
+            <p>Inspired from:</p>
+            <ul>
+              <li><a href="https://confcodeofconduct.com/">https://confcodeofconduct.com/</a></li>
+              <li><a
+                  href="https://www.ashedryden.com/blog/codes-of-conduct-101-faq">https://www.ashedryden.com/blog/codes-of-conduct-101-faq</a>
+              </li>
+              <li><a href="http://citizencodeofconduct.org/">http://citizencodeofconduct.org/</a></li>
+            </ul>
+            <p>Published under CC-BY-SA</p>
+
+            <p></p>
+
+          </div>
+        </div>
+      </section>
+
+    </section>
+
+    <!-- Footer -->
+    <section id="footer">
+      <div class="inner">
+        <h2 class="major">Get in touch about Talks or Sponsorship</h2>
+        <p>If you would like to propose a talk, don't be shy, just use this form and contact us :) We are also open for
+          any kind of help or sponsorship. With regards to sponsorship, we are mainly looking for companies /
+          organisations that would like to host our events in Luxembourg-City and offer the catering in exchange of some
+          visibility. We can propose to display the name and logo of your company on the meetup event page, we will
+          thank you in tweets about the event and we will thank you during the event.</p>
+        <form method="post" action="https://formspree.io/luxembourgjs.com@gmail.com">
+          <div class="fields">
+            <div class="field">
+              <label for="name">Name</label>
+              <input type="text" name="name" id="name" />
+            </div>
+            <div class="field">
+              <label for="email">Email</label>
+              <input type="email" name="email" id="email" />
+            </div>
+            <div class="field">
+              <label for="message">Message</label>
+              <textarea name="message" id="message" rows="4"></textarea>
+            </div>
+            <input type="text" name="_gotcha" style="display:none" />
+          </div>
+          <ul class="actions">
+            <li><input type="submit" value="Send Message" /></li>
+          </ul>
+        </form>
+        <ul class="contact">
+          <li class="fa-twitter"><a href="https://twitter.com/luxembourgjs">twitter.com/luxembourgjs</a></li>
+          <li class="fa-facebook"><a
+              href="https://www.facebook.com/groups/luxembourgjs/">facebook.com/groups/luxembourgjs</a></li>
+        </ul>
+        <ul class="copyright">
+          <li>&copy; LuxembourgJS. All rights reserved.</li>
+          <li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+        </ul>
+      </div>
+    </section>
+
+  </div>
+
+  <!-- Scripts -->
+  <script src="theme/assets/js/jquery.min.js"></script>
+  <script src="theme/assets/js/jquery.scrollex.min.js"></script>
+  <script src="theme/assets/js/browser.min.js"></script>
+  <script src="theme/assets/js/breakpoints.min.js"></script>
+  <script src="theme/assets/js/util.js"></script>
+  <script src="theme/assets/js/main.js"></script>
+
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -197,67 +197,67 @@
           <section class="features">
             
               <article>
-                <a href="https://docs.google.com/presentation/d/16_yZG-Z4wuVkluaAuSvo0d4qaJcBcy6BEuSH71JRivY/edit?usp=sharing" class="image">
+                <a href="https://docs.google.com/presentation/d/16_yZG-Z4wuVkluaAuSvo0d4qaJcBcy6BEuSH71JRivY/edit?usp=sharing" rel="nofollow" class="image">
                   <img src="pres_thumb/workbox_VSa.png" alt="Creating powerful offline experiences with Workbox" />
                 </a>
                 <h3 class="major">Creating powerful offline experiences with Workbox</h3>
                 <p>by
-                  <a href="https://twitter.com/samvloeberghs">Sam Vloeberghs</a>
+                  <a href="https://twitter.com/samvloeberghs" rel="nofollow">Sam Vloeberghs</a>
                   / October 2019
                 </p>
-                <a href="https://docs.google.com/presentation/d/16_yZG-Z4wuVkluaAuSvo0d4qaJcBcy6BEuSH71JRivY/edit?usp=sharing" class="special">Slides</a>
+                <a href="https://docs.google.com/presentation/d/16_yZG-Z4wuVkluaAuSvo0d4qaJcBcy6BEuSH71JRivY/edit?usp=sharing" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="http://lekzd.ru/presentations/webgl_simple_luxembourg/" class="image">
+                <a href="http://lekzd.ru/presentations/webgl_simple_luxembourg/" rel="nofollow" class="image">
                   <img src="pres_thumb/webgl_AKo.png" alt="WebGL and 2D: simple as Web" />
                 </a>
                 <h3 class="major">WebGL and 2D: simple as Web</h3>
                 <p>by
-                  <a href="https://github.com/lekzd">Aleksandr Korotaev</a>
+                  <a href="https://github.com/lekzd" rel="nofollow">Aleksandr Korotaev</a>
                   / June 2019
                 </p>
-                <a href="http://lekzd.ru/presentations/webgl_simple_luxembourg/" class="special">Slides</a>
+                <a href="http://lekzd.ru/presentations/webgl_simple_luxembourg/" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://docs.google.com/presentation/d/1BHJRpiEWq1mIz6uIgV8D2mVGxJ33LNVDHDVT_hwsqx4/edit" class="image">
+                <a href="https://docs.google.com/presentation/d/1BHJRpiEWq1mIz6uIgV8D2mVGxJ33LNVDHDVT_hwsqx4/edit" rel="nofollow" class="image">
                   <img src="pres_thumb/accessibility_in_practice.png" alt="Accessibility in practice" />
                 </a>
                 <h3 class="major">Accessibility in practice</h3>
                 <p>by
-                  <a href="https://twitter.com/pttmary">Marie Baudy</a> & Artur Spulnik
+                  <a href="https://twitter.com/pttmary" rel="nofollow">Marie Baudy</a> & Artur Spulnik
                   / June 2019
                 </p>
-                <a href="https://docs.google.com/presentation/d/1BHJRpiEWq1mIz6uIgV8D2mVGxJ33LNVDHDVT_hwsqx4/edit" class="special">Slides</a>
+                <a href="https://docs.google.com/presentation/d/1BHJRpiEWq1mIz6uIgV8D2mVGxJ33LNVDHDVT_hwsqx4/edit" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://github.com/kawan16/nest-heroes/raw/master/Meetup%20Javascript%20Luxembourg%20-%20Nest.pdf" class="image">
+                <a href="https://github.com/kawan16/nest-heroes/raw/master/Meetup%20Javascript%20Luxembourg%20-%20Nest.pdf" rel="nofollow" class="image">
                   <img src="pres_thumb/nest_DKa.png" alt="Nest - A Progressive Node.js Framework" />
                 </a>
                 <h3 class="major">Nest - A Progressive Node.js Framework</h3>
                 <p>by
-                  <a href="https://github.com/kawan16">Karl Devooght</a>
+                  <a href="https://github.com/kawan16" rel="nofollow">Karl Devooght</a>
                   / May 2019
                 </p>
-                <a href="https://github.com/kawan16/nest-heroes/raw/master/Meetup%20Javascript%20Luxembourg%20-%20Nest.pdf" class="special">Slides</a>
+                <a href="https://github.com/kawan16/nest-heroes/raw/master/Meetup%20Javascript%20Luxembourg%20-%20Nest.pdf" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://www.slideshare.net/CrowChick/vue-in-motion" class="image">
+                <a href="https://www.slideshare.net/CrowChick/vue-in-motion" rel="nofollow" class="image">
                   <img src="pres_thumb/vue_in_motion_NRa.png" alt="Vue in Motion" />
                 </a>
                 <h3 class="major">Vue in Motion</h3>
                 <p>by
-                  <a href="http://rachelnabors.com/">Rachel Nabors</a>
+                  <a href="http://rachelnabors.com/" rel="nofollow">Rachel Nabors</a>
                   / April 2019
                 </p>
-                <a href="https://www.slideshare.net/CrowChick/vue-in-motion" class="special">Slides</a>
+                <a href="https://www.slideshare.net/CrowChick/vue-in-motion" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="pres/intro_vue.pdf" class="image">
+                <a href="pres/intro_vue.pdf" rel="nofollow" class="image">
                   <img src="pres_thumb/intro_vue_BSa.png" alt="Intro to Vue.js" />
                 </a>
                 <h3 class="major">Intro to Vue.js</h3>
@@ -265,95 +265,95 @@
                   Sami Boudrai
                   / April 2019
                 </p>
-                <a href="pres/intro_vue.pdf" class="special">Slides</a>
+                <a href="pres/intro_vue.pdf" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://stephaniewalter.design/blog/lightning-fast-ux-faking-performance-when-theres-no-code-left-to-optimize/" class="image">
+                <a href="https://stephaniewalter.design/blog/lightning-fast-ux-faking-performance-when-theres-no-code-left-to-optimize/" rel="nofollow" class="image">
                   <img src="pres_thumb/lightning_fast_ux_SWa.jpg" alt="Lightning fast UX: faking performance when there’s no code left to optimize" />
                 </a>
                 <h3 class="major">Lightning fast UX: faking performance when there’s no code left to optimize</h3>
                 <p>by
-                  <a href="https://twitter.com/walterstephanie">Stéphanie Walter</a>
+                  <a href="https://twitter.com/walterstephanie" rel="nofollow">Stéphanie Walter</a>
                   / March 2019
                 </p>
-                <a href="https://stephaniewalter.design/blog/lightning-fast-ux-faking-performance-when-theres-no-code-left-to-optimize/" class="special">Slides</a>
+                <a href="https://stephaniewalter.design/blog/lightning-fast-ux-faking-performance-when-theres-no-code-left-to-optimize/" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="pres/webperf_2019.pptx" class="image">
+                <a href="pres/webperf_2019.pptx" rel="nofollow" class="image">
                   <img src="pres_thumb/web_perf_2019_JEv.png" alt="Web Performance in 2019" />
                 </a>
                 <h3 class="major">Web Performance in 2019</h3>
                 <p>by
-                  <a href="https://twitter.com/theystolemynick">Jean-pierre Vincent</a>
+                  <a href="https://twitter.com/theystolemynick" rel="nofollow">Jean-pierre Vincent</a>
                   / March 2019
                 </p>
-                <a href="pres/webperf_2019.pptx" class="special">Slides</a>
+                <a href="pres/webperf_2019.pptx" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://krampstudio.com/offline-webapp-talk/" class="image">
+                <a href="https://krampstudio.com/offline-webapp-talk/" rel="nofollow" class="image">
                   <img src="pres_thumb/offline-web-app_XYZ.png" alt="Offline Web Apps" />
                 </a>
                 <h3 class="major">Offline Web Apps</h3>
                 <p>by
-                  <a href="https://twitter.com/kramp">Bertrand Chevrier</a>
+                  <a href="https://twitter.com/kramp" rel="nofollow">Bertrand Chevrier</a>
                   / February 2019
                 </p>
-                <a href="https://krampstudio.com/offline-webapp-talk/" class="special">Slides</a>
+                <a href="https://krampstudio.com/offline-webapp-talk/" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://stephaniewalter.design/blog/super-secret-powers-of-mobile-browsers-talk-slides/" class="image">
+                <a href="https://stephaniewalter.design/blog/super-secret-powers-of-mobile-browsers-talk-slides/" rel="nofollow" class="image">
                   <img src="pres_thumb/mobile_browsers_SWa.png" alt="Super Secret Powers of Mobile Browsers" />
                 </a>
                 <h3 class="major">Super Secret Powers of Mobile Browsers</h3>
                 <p>by
-                  <a href="https://twitter.com/walterstephanie">Stéphanie Walter</a>
+                  <a href="https://twitter.com/walterstephanie" rel="nofollow">Stéphanie Walter</a>
                   / January 2019
                 </p>
-                <a href="https://stephaniewalter.design/blog/super-secret-powers-of-mobile-browsers-talk-slides/" class="special">Slides</a>
+                <a href="https://stephaniewalter.design/blog/super-secret-powers-of-mobile-browsers-talk-slides/" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://docs.google.com/presentation/d/1HCeTpKv6lCXCGJFtkRFoVbkmd_C5-Ggv4h4JlxHyaXQ/edit#slide=id.g45f10dffa6_0_0" class="image">
+                <a href="https://docs.google.com/presentation/d/1HCeTpKv6lCXCGJFtkRFoVbkmd_C5-Ggv4h4JlxHyaXQ/edit#slide=id.g45f10dffa6_0_0" rel="nofollow" class="image">
                   <img src="pres_thumb/typescript_GMo.png" alt="Typescript: tips and best practices" />
                 </a>
                 <h3 class="major">Typescript: tips and best practices</h3>
                 <p>by
-                  <a href="https://twitter.com/255kb">Guillaume Monnet</a> & <a href="https://github.com/thomaswinckell">Thomas Winckell</a>
+                  <a href="https://twitter.com/255kb" rel="nofollow">Guillaume Monnet</a> & <a href="https://github.com/thomaswinckell" rel="nofollow">Thomas Winckell</a>
                   / December 2018
                 </p>
-                <a href="https://docs.google.com/presentation/d/1HCeTpKv6lCXCGJFtkRFoVbkmd_C5-Ggv4h4JlxHyaXQ/edit#slide=id.g45f10dffa6_0_0" class="special">Slides</a>
+                <a href="https://docs.google.com/presentation/d/1HCeTpKv6lCXCGJFtkRFoVbkmd_C5-Ggv4h4JlxHyaXQ/edit#slide=id.g45f10dffa6_0_0" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://www.slideshare.net/vasilikaklimova/webgl-practical-application" class="image">
+                <a href="https://www.slideshare.net/vasilikaklimova/webgl-practical-application" rel="nofollow" class="image">
                   <img src="pres_thumb/webgl_VKl.png" alt="WebGL Practical application" />
                 </a>
                 <h3 class="major">WebGL Practical application</h3>
                 <p>by
-                  <a href="https://twitter.com/lik04ka">Vasilika Klimova</a>
+                  <a href="https://twitter.com/lik04ka" rel="nofollow">Vasilika Klimova</a>
                   / December 2018
                 </p>
-                <a href="https://www.slideshare.net/vasilikaklimova/webgl-practical-application" class="special">Slides</a>
+                <a href="https://www.slideshare.net/vasilikaklimova/webgl-practical-application" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://slides.com/nicolasfrizzarin/angular-element/fullscreen" class="image">
+                <a href="https://slides.com/nicolasfrizzarin/angular-element/fullscreen" rel="nofollow" class="image">
                   <img src="pres_thumb/angular_element_NFr.png" alt="Angular Element" />
                 </a>
                 <h3 class="major">Angular Element</h3>
                 <p>by
-                  <a href="https://twitter.com/Nicooss54">Nicolas Frizzarin</a>
+                  <a href="https://twitter.com/Nicooss54" rel="nofollow">Nicolas Frizzarin</a>
                   / November 2018
                 </p>
-                <a href="https://slides.com/nicolasfrizzarin/angular-element/fullscreen" class="special">Slides</a>
+                <a href="https://slides.com/nicolasfrizzarin/angular-element/fullscreen" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="pres/devops_SBo.pdf" class="image">
+                <a href="pres/devops_SBo.pdf" rel="nofollow" class="image">
                   <img src="pres_thumb/devops_SBo.png" alt="Deploy fast and well" />
                 </a>
                 <h3 class="major">Deploy fast and well</h3>
@@ -361,175 +361,175 @@
                   Sami Boudrai
                   / November 2018
                 </p>
-                <a href="pres/devops_SBo.pdf" class="special">Slides</a>
+                <a href="pres/devops_SBo.pdf" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://docs.google.com/presentation/d/1lhDgVUUWlqhN6ZbWL1Dad0QUwcxPV8zMHp9ssRohZxA/edit?usp=sharing" class="image">
+                <a href="https://docs.google.com/presentation/d/1lhDgVUUWlqhN6ZbWL1Dad0QUwcxPV8zMHp9ssRohZxA/edit?usp=sharing" rel="nofollow" class="image">
                   <img src="pres_thumb/mockoon_GUm.png" alt="Mockoon" />
                 </a>
                 <h3 class="major">Mockoon</h3>
                 <p>by
-                  <a href="https://twitter.com/255kb">Guillaume Monnet</a>
+                  <a href="https://twitter.com/255kb" rel="nofollow">Guillaume Monnet</a>
                   / October 2018
                 </p>
-                <a href="https://docs.google.com/presentation/d/1lhDgVUUWlqhN6ZbWL1Dad0QUwcxPV8zMHp9ssRohZxA/edit?usp=sharing" class="special">Slides</a>
+                <a href="https://docs.google.com/presentation/d/1lhDgVUUWlqhN6ZbWL1Dad0QUwcxPV8zMHp9ssRohZxA/edit?usp=sharing" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://becoming.lu/about" class="image">
+                <a href="https://becoming.lu/about" rel="nofollow" class="image">
                   <img src="pres_thumb/becominglu_ROm.png" alt="Becoming.lu" />
                 </a>
                 <h3 class="major">Becoming.lu</h3>
                 <p>by
-                  <a href="https://bitbucket.org/rodislav">Rodislav Moldovan</a>
+                  <a href="https://bitbucket.org/rodislav" rel="nofollow">Rodislav Moldovan</a>
                   / October 2018
                 </p>
-                <a href="https://becoming.lu/about" class="special">Slides</a>
+                <a href="https://becoming.lu/about" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://github.com/ffauchille/js-meetup-lu-chatbot" class="image">
+                <a href="https://github.com/ffauchille/js-meetup-lu-chatbot" rel="nofollow" class="image">
                   <img src="pres_thumb/chatbot_FFa.png" alt="Building chatbots without Cloud" />
                 </a>
                 <h3 class="major">Building chatbots without Cloud</h3>
                 <p>by
-                  <a href="https://github.com/ffauchille">Florent Fauchille</a>
+                  <a href="https://github.com/ffauchille" rel="nofollow">Florent Fauchille</a>
                   / September 2018
                 </p>
-                <a href="https://github.com/ffauchille/js-meetup-lu-chatbot" class="special">Slides</a>
+                <a href="https://github.com/ffauchille/js-meetup-lu-chatbot" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://dom99.now.sh/presentation/reveal.js-2.6.2/test/examples/dom99" class="image">
+                <a href="https://dom99.now.sh/presentation/reveal.js-2.6.2/test/examples/dom99" rel="nofollow" class="image">
                   <img src="pres_thumb/dom99_CWa.png" alt="dom99" />
                 </a>
                 <h3 class="major">dom99</h3>
                 <p>by
-                  <a href="https://github.com/GrosSacASac">Cyril Walle</a>
+                  <a href="https://github.com/GrosSacASac" rel="nofollow">Cyril Walle</a>
                   / September 2018
                 </p>
-                <a href="https://dom99.now.sh/presentation/reveal.js-2.6.2/test/examples/dom99" class="special">Slides</a>
+                <a href="https://dom99.now.sh/presentation/reveal.js-2.6.2/test/examples/dom99" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://speakerdeck.com/littleiffel/reflections-on-operating-a-serverless-api" class="image">
+                <a href="https://speakerdeck.com/littleiffel/reflections-on-operating-a-serverless-api" rel="nofollow" class="image">
                   <img src="pres_thumb/serverless_TNi.jpg" alt="On Serverless - Using Serverless in Production" />
                 </a>
                 <h3 class="major">On Serverless - Using Serverless in Production</h3>
                 <p>by
-                  <a href="https://twitter.com/littleiffel">Thierry Nicola</a>
+                  <a href="https://twitter.com/littleiffel" rel="nofollow">Thierry Nicola</a>
                   / June 2018
                 </p>
-                <a href="https://speakerdeck.com/littleiffel/reflections-on-operating-a-serverless-api" class="special">Slides</a>
+                <a href="https://speakerdeck.com/littleiffel/reflections-on-operating-a-serverless-api" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://www.dropbox.com/s/gwayo9hn7vfv2q1/CSS-Variables.pdf?dl=0" class="image">
+                <a href="https://www.dropbox.com/s/gwayo9hn7vfv2q1/CSS-Variables.pdf?dl=0" rel="nofollow" class="image">
                   <img src="pres_thumb/css_variables_GCr.jpg" alt="CSS Variables in the real life" />
                 </a>
                 <h3 class="major">CSS Variables in the real life</h3>
                 <p>by
-                  <a href="https://twitter.com/geoffrey_crofte">Geoffrey Crofte</a>
+                  <a href="https://twitter.com/geoffrey_crofte" rel="nofollow">Geoffrey Crofte</a>
                   / May 2018
                 </p>
-                <a href="https://www.dropbox.com/s/gwayo9hn7vfv2q1/CSS-Variables.pdf?dl=0" class="special">Slides</a>
+                <a href="https://www.dropbox.com/s/gwayo9hn7vfv2q1/CSS-Variables.pdf?dl=0" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://slides.com/alainvagner/deck#/" class="image">
+                <a href="https://slides.com/alainvagner/deck#/" rel="nofollow" class="image">
                   <img src="pres_thumb/accessibility_101_AVa.jpg" alt="Accessibility 101" />
                 </a>
                 <h3 class="major">Accessibility 101</h3>
                 <p>by
-                  <a href="https://twitter.com/biou">Alain Vagner</a>
+                  <a href="https://twitter.com/biou" rel="nofollow">Alain Vagner</a>
                   / May 2018
                 </p>
-                <a href="https://slides.com/alainvagner/deck#/" class="special">Slides</a>
+                <a href="https://slides.com/alainvagner/deck#/" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://github.com/ou2s/slides/raw/master/JSMeetup%20Luxembourg%20-%2003042018/JSMeetup_RN_in_Production.pdf" class="image">
+                <a href="https://github.com/ou2s/slides/raw/master/JSMeetup%20Luxembourg%20-%2003042018/JSMeetup_RN_in_Production.pdf" rel="nofollow" class="image">
                   <img src="pres_thumb/react_native_OGh.jpg" alt="React Native in production" />
                 </a>
                 <h3 class="major">React Native in production</h3>
                 <p>by
-                  <a href="https://github.com/ou2s">Oussama Ghalbzouri</a>
+                  <a href="https://github.com/ou2s" rel="nofollow">Oussama Ghalbzouri</a>
                   / April 2018
                 </p>
-                <a href="https://github.com/ou2s/slides/raw/master/JSMeetup%20Luxembourg%20-%2003042018/JSMeetup_RN_in_Production.pdf" class="special">Slides</a>
+                <a href="https://github.com/ou2s/slides/raw/master/JSMeetup%20Luxembourg%20-%2003042018/JSMeetup_RN_in_Production.pdf" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://github.com/GrosSacASac/JavaScript-Set-Up/tree/master/general/html-streaming" class="image">
+                <a href="https://github.com/GrosSacASac/JavaScript-Set-Up/tree/master/general/html-streaming" rel="nofollow" class="image">
                   <img src="pres_thumb/html_streaming_CWa.jpg" alt="HTML Streaming" />
                 </a>
                 <h3 class="major">HTML Streaming</h3>
                 <p>by
-                  <a href="https://github.com/GrosSacASac/">Cyril Walle</a>
+                  <a href="https://github.com/GrosSacASac/" rel="nofollow">Cyril Walle</a>
                   / April 2018
                 </p>
-                <a href="https://github.com/GrosSacASac/JavaScript-Set-Up/tree/master/general/html-streaming" class="special">Slides</a>
+                <a href="https://github.com/GrosSacASac/JavaScript-Set-Up/tree/master/general/html-streaming" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://github.com/anton-kabysh/flowtype-experiments" class="image">
+                <a href="https://github.com/anton-kabysh/flowtype-experiments" rel="nofollow" class="image">
                   <img src="pres_thumb/flow_type_AKa.jpg" alt="Let your types Flow. Pragmatic introduction to Flowtype" />
                 </a>
                 <h3 class="major">Let your types Flow. Pragmatic introduction to Flowtype</h3>
                 <p>by
-                  <a href="https://github.com/anton-kabysh">Anton Kabysh</a>
+                  <a href="https://github.com/anton-kabysh" rel="nofollow">Anton Kabysh</a>
                   / March 2018
                 </p>
-                <a href="https://github.com/anton-kabysh/flowtype-experiments" class="special">Slides</a>
+                <a href="https://github.com/anton-kabysh/flowtype-experiments" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://docs.google.com/presentation/d/1E8Cz1QX6nLKzG7Vul9bX8hby9u22iT3k2gByCnBHcyM/edit?usp=sharing" class="image">
+                <a href="https://docs.google.com/presentation/d/1E8Cz1QX6nLKzG7Vul9bX8hby9u22iT3k2gByCnBHcyM/edit?usp=sharing" rel="nofollow" class="image">
                   <img src="pres_thumb/ionic_ASp.jpg" alt="IONIC 3 from scratch to store" />
                 </a>
                 <h3 class="major">IONIC 3 from scratch to store</h3>
                 <p>by
-                  <a href="https://twitter.com/arthurspitznage">Arthur Spitznagel</a>
+                  <a href="https://twitter.com/arthurspitznage" rel="nofollow">Arthur Spitznagel</a>
                   / February 2018
                 </p>
-                <a href="https://docs.google.com/presentation/d/1E8Cz1QX6nLKzG7Vul9bX8hby9u22iT3k2gByCnBHcyM/edit?usp=sharing" class="special">Slides</a>
+                <a href="https://docs.google.com/presentation/d/1E8Cz1QX6nLKzG7Vul9bX8hby9u22iT3k2gByCnBHcyM/edit?usp=sharing" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://github.com/Algar/JSLuxembourg-February2018-VisualRegressionTesting" class="image">
+                <a href="https://github.com/Algar/JSLuxembourg-February2018-VisualRegressionTesting" rel="nofollow" class="image">
                   <img src="pres_thumb/visual_regression_AGa.jpg" alt="Visual regression testing" />
                 </a>
                 <h3 class="major">Visual regression testing</h3>
                 <p>by
-                  <a href="https://www.yotako.io">Alfonso Garcia</a>
+                  <a href="https://www.yotako.io" rel="nofollow">Alfonso Garcia</a>
                   / February 2018
                 </p>
-                <a href="https://github.com/Algar/JSLuxembourg-February2018-VisualRegressionTesting" class="special">Slides</a>
+                <a href="https://github.com/Algar/JSLuxembourg-February2018-VisualRegressionTesting" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://docs.google.com/presentation/d/10dvXKYrEZ_H8MElw6Cdpd4u5COBpJPlquT6Kf2o9iNs/edit?usp=sharing" class="image">
+                <a href="https://docs.google.com/presentation/d/10dvXKYrEZ_H8MElw6Cdpd4u5COBpJPlquT6Kf2o9iNs/edit?usp=sharing" rel="nofollow" class="image">
                   <img src="pres_thumb/graphql_TNi.jpg" alt="What the QL? Introduction to GraphQL." />
                 </a>
                 <h3 class="major">What the QL? Introduction to GraphQL.</h3>
                 <p>by
-                  <a href="https://twitter.com/littleiffel">Thierry Nicola</a>
+                  <a href="https://twitter.com/littleiffel" rel="nofollow">Thierry Nicola</a>
                   / January 2018
                 </p>
-                <a href="https://docs.google.com/presentation/d/10dvXKYrEZ_H8MElw6Cdpd4u5COBpJPlquT6Kf2o9iNs/edit?usp=sharing" class="special">Slides</a>
+                <a href="https://docs.google.com/presentation/d/10dvXKYrEZ_H8MElw6Cdpd4u5COBpJPlquT6Kf2o9iNs/edit?usp=sharing" class="special" rel="nofollow">Slides</a>
               </article>
             
               <article>
-                <a href="https://js-mf.github.io/" class="image">
+                <a href="https://js-mf.github.io/" rel="nofollow" class="image">
                   <img src="pres_thumb/jsmf_JSo.jpg" alt="The JavaScript Way of Model-Driven Engineering" />
                 </a>
                 <h3 class="major">The JavaScript Way of Model-Driven Engineering</h3>
                 <p>by
-                  <a href="https://twitter.com/reversal_js">Jean-Sébastien Sottet</a>
+                  <a href="https://twitter.com/reversal_js" rel="nofollow">Jean-Sébastien Sottet</a>
                   / January 2018
                 </p>
-                <a href="https://js-mf.github.io/" class="special">Slides</a>
+                <a href="https://js-mf.github.io/" class="special" rel="nofollow">Slides</a>
               </article>
             
           </section>

--- a/index.html
+++ b/index.html
@@ -195,219 +195,343 @@
           <h2 class="major" id="slides">Last talks &amp; slides</h2>
           <p>You can find here the slides from the latest talks that have been given during our meetups.</p>
           <section class="features">
-            <article>
-              <a href="https://docs.google.com/presentation/d/16_yZG-Z4wuVkluaAuSvo0d4qaJcBcy6BEuSH71JRivY/edit?usp=sharing"
-                class="image"><img src="pres_thumb/workbox_VSa.png"
-                  alt="Creating powerful offline experiences with Workbox" /></a>
-              <h3 class="major">Creating powerful offline experiences with Workbox</h3>
-              <p>by <a href="https://twitter.com/samvloeberghs">Sam Vloeberghs</a> / October 2019</p>
-              <a href="https://docs.google.com/presentation/d/16_yZG-Z4wuVkluaAuSvo0d4qaJcBcy6BEuSH71JRivY/edit?usp=sharing"
-                class="special">Slides</a>
-            </article>
-            <article>
-              <a href="http://lekzd.ru/presentations/webgl_simple_luxembourg/" class="image"><img
-                  src="pres_thumb/webgl_AKo.png" alt="WebGL and 2D: simple as Web" /></a>
-              <h3 class="major">WebGL and 2D: simple as Web</h3>
-              <p>by <a href="https://github.com/lekzd">Aleksandr Korotaev</a> / June 2019</p>
-              <a href="http://lekzd.ru/presentations/webgl_simple_luxembourg/" class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://docs.google.com/presentation/d/1BHJRpiEWq1mIz6uIgV8D2mVGxJ33LNVDHDVT_hwsqx4/edit" class="image"><img src="pres_thumb/accessibility_in_practice.png" alt="Accessibility in practice" /></a>
-              <h3 class="major">Accessibility in practice</h3>
-              <p>by <a href="https://twitter.com/pttmary">Marie Baudy</a> & Artur Spulnik / June 2019</p>
-              <a href="https://docs.google.com/presentation/d/1BHJRpiEWq1mIz6uIgV8D2mVGxJ33LNVDHDVT_hwsqx4/edit" class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://github.com/kawan16/nest-heroes/raw/master/Meetup%20Javascript%20Luxembourg%20-%20Nest.pdf"
-                class="image"><img src="pres_thumb/nest_DKa.png" alt="Nest - A Progressive Node.js Framework" /></a>
-              <h3 class="major">Nest - A Progressive Node.js Framework</h3>
-              <p>by <a href="https://github.com/kawan16">Karl Devooght</a> / May 2019</p>
-              <a href="https://github.com/kawan16/nest-heroes/raw/master/Meetup%20Javascript%20Luxembourg%20-%20Nest.pdf"
-                class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://www.slideshare.net/CrowChick/vue-in-motion" class="image"><img
-                  src="pres_thumb/vue_in_motion_NRa.png" alt="Vue in Motion" /></a>
-              <h3 class="major">Vue in Motion</h3>
-              <p>by <a href="http://rachelnabors.com/">Rachel Nabors</a> / April 2019</p>
-              <a href="https://www.slideshare.net/CrowChick/vue-in-motion" class="special">Slides</a>
-            </article>
-            <article>
-              <a href="pres/intro_vue.pdf" class="image"><img src="pres_thumb/intro_vue_BSa.png"
-                  alt="Intro to Vue.js" /></a>
-              <h3 class="major">Intro to Vue.js</h3>
-              <p>by Sami Boudrai / April 2019</p>
-              <a href="pres/intro_vue.pdf" class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://stephaniewalter.design/blog/lightning-fast-ux-faking-performance-when-theres-no-code-left-to-optimize/"
-                class="image"><img src="pres_thumb/lightning_fast_ux_SWa.jpg"
-                  alt="Lightning fast UX: faking performance when there’s no code left to optimize" /></a>
-              <h3 class="major">Lightning fast UX: faking performance when there’s no code left to optimize</h3>
-              <p>by <a href="https://twitter.com/walterstephanie">Stéphanie Walter</a> / March 2019</p>
-              <a href="https://stephaniewalter.design/blog/lightning-fast-ux-faking-performance-when-theres-no-code-left-to-optimize/"
-                class="special">Slides</a>
-            </article>
-            <article>
-              <a href="pres/webperf_2019.pptx" class="image"><img src="pres_thumb/web_perf_2019_JEv.png"
-                  alt="Web Performance in 2019" /></a>
-              <h3 class="major">Web Performance in 2019</h3>
-              <p>by <a href="https://twitter.com/theystolemynick">Jean-pierre Vincent</a> / March 2019</p>
-              <a href="pres/webperf_2019.pptx" class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://krampstudio.com/offline-webapp-talk/" class="image"><img
-                  src="./pres_thumb/offline-web-app_XYZ.png" alt="Offline Web App" /></a>
-              <h3 class="major">Offline Web Apps</h3>
-              <p>by <a href="https://twitter.com/kramp">Bertrand Chevrier</a> / February 2019</p>
-              <a href="https://krampstudio.com/offline-webapp-talk/" class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://stephaniewalter.design/blog/super-secret-powers-of-mobile-browsers-talk-slides/"
-                class="image"><img src="pres_thumb/mobile_browsers_SWa.png"
-                  alt="Super Secret Powers of Mobile Browsers" /></a>
-              <h3 class="major">Super Secret Powers of Mobile Browsers</h3>
-              <p>by <a href="https://twitter.com/walterstephanie">Stéphanie Walter</a> / January 2019</p>
-              <a href="https://stephaniewalter.design/blog/super-secret-powers-of-mobile-browsers-talk-slides/"
-                class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://docs.google.com/presentation/d/1HCeTpKv6lCXCGJFtkRFoVbkmd_C5-Ggv4h4JlxHyaXQ/edit#slide=id.g45f10dffa6_0_0"
-                class="image"><img src="pres_thumb/typescript_GMo.png" alt="Typescript: tips and best practices" /></a>
-              <h3 class="major">Typescript: tips and best practices</h3>
-              <p>by <a href="https://twitter.com/255kb">Guillaume Monnet</a> & <a
-                  href="https://github.com/thomaswinckell">Thomas Winckell</a> / December 2018</p>
-              <a href="https://docs.google.com/presentation/d/1HCeTpKv6lCXCGJFtkRFoVbkmd_C5-Ggv4h4JlxHyaXQ/edit#slide=id.g45f10dffa6_0_0"
-                class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://www.slideshare.net/vasilikaklimova/webgl-practical-application" class="image"><img
-                  src="pres_thumb/webgl_VKl.png" alt="WebGL Practical application" /></a>
-              <h3 class="major">WebGL Practical application</h3>
-              <p>by <a href="https://twitter.com/lik04ka">Vasilika Klimova</a> / December 2018</p>
-              <a href="https://www.slideshare.net/vasilikaklimova/webgl-practical-application"
-                class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://slides.com/nicolasfrizzarin/angular-element/fullscreen" class="image"><img
-                  src="pres_thumb/angular_element_NFr.png" alt="Angular Element" /></a>
-              <h3 class="major">Angular Element</h3>
-              <p>by <a href="https://twitter.com/Nicooss54">Nicolas Frizzarin</a> / November 2018</p>
-              <a href="https://slides.com/nicolasfrizzarin/angular-element/fullscreen" class="special">Slides</a>
-            </article>
-            <article>
-              <a href="pres/devops_SBo.pdf" class="image"><img src="pres_thumb/devops_SBo.png"
-                  alt="Deploy fast and well" /></a>
-              <h3 class="major">Deploy fast and well</h3>
-              <p>by Sami Boudrai / November 2018</p>
-              <a href="pres/devops_SBo.pdf" class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://docs.google.com/presentation/d/1lhDgVUUWlqhN6ZbWL1Dad0QUwcxPV8zMHp9ssRohZxA/edit?usp=sharing"
-                class="image"><img src="pres_thumb/mockoon_GUm.png" alt="Mockoon" /></a>
-              <h3 class="major">Mockoon</h3>
-              <p>by <a href="https://github.com/255kb">Guillaume Monnet</a> / October 2018</p>
-              <a href="https://docs.google.com/presentation/d/1lhDgVUUWlqhN6ZbWL1Dad0QUwcxPV8zMHp9ssRohZxA/edit?usp=sharing"
-                class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://becoming.lu/about" class="image"><img src="pres_thumb/becominglu_ROm.png"
-                  alt="Becoming.lu" /></a>
-              <h3 class="major">Becoming.lu</h3>
-              <p>by <a href="https://bitbucket.org/rodislav">Rodislav Moldovan</a> / October 2018</p>
-              <a href="https://becoming.lu/about" class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://github.com/ffauchille/js-meetup-lu-chatbot" class="image"><img
-                  src="pres_thumb/chatbot_FFa.png" alt="Building chatbot without cloud" /></a>
-              <h3 class="major">Building chatbots without Cloud</h3>
-              <p>by <a href="https://github.com/ffauchille">Florent Fauchille</a> / September 2018</p>
-              <a href="https://github.com/ffauchille/js-meetup-lu-chatbot" class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://dom99.now.sh/presentation/reveal.js-2.6.2/test/examples/dom99" class="image"><img
-                  src="pres_thumb/dom99_CWa.png" alt="dom99" /></a>
-              <h3 class="major">dom99</h3>
-              <p>by <a href="https://github.com/GrosSacASac">Cyril Walle</a> / September 2018</p>
-              <a href="https://dom99.now.sh/presentation/reveal.js-2.6.2/test/examples/dom99" class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://speakerdeck.com/littleiffel/reflections-on-operating-a-serverless-api" class="image"><img
-                  src="pres_thumb/serverless_TNi.jpg" alt="On Serverless - Using Serverless in Production" /></a>
-              <h3 class="major">On Serverless - Using Serverless in Production</h3>
-              <p>by <a href="https://twitter.com/littleiffel">Thierry Nicola</a> / June 2018</p>
-              <a href="https://speakerdeck.com/littleiffel/reflections-on-operating-a-serverless-api"
-                class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://www.dropbox.com/s/gwayo9hn7vfv2q1/CSS-Variables.pdf?dl=0" class="image"><img
-                  src="pres_thumb/css_variables_GCr.jpg" alt="CSS Variables in the real life" /></a>
-              <h3 class="major">CSS Variables in the real life</h3>
-              <p>by <a href="https://twitter.com/geoffrey_crofte">Geoffrey Crofte</a> / May 2018</p>
-              <a href="https://www.dropbox.com/s/gwayo9hn7vfv2q1/CSS-Variables.pdf?dl=0" class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://slides.com/alainvagner/deck#/" class="image"><img
-                  src="pres_thumb/accessibility_101_AVa.jpg" alt="Accessibility 101" /></a>
-              <h3 class="major">Accessibility 101</h3>
-              <p>by <a href="https://twitter.com/biou">Alain Vagner</a> / May 2018</p>
-              <a href="https://slides.com/alainvagner/deck#/" class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://github.com/ou2s/slides/raw/master/JSMeetup%20Luxembourg%20-%2003042018/JSMeetup_RN_in_Production.pdf"
-                class="image"><img src="pres_thumb/react_native_OGh.jpg" alt="React Native in production" /></a>
-              <h3 class="major">React Native in production</h3>
-              <p>by <a href="https://github.com/ou2s">Oussama Ghalbzouri</a> / April 2018</p>
-              <a href="https://github.com/ou2s/slides/raw/master/JSMeetup%20Luxembourg%20-%2003042018/JSMeetup_RN_in_Production.pdf"
-                class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://github.com/GrosSacASac/JavaScript-Set-Up/tree/master/general/html-streaming"
-                class="image"><img src="pres_thumb/html_streaming_CWa.jpg" alt="HTML Streaming" /></a>
-              <h3 class="major">HTML Streaming</h3>
-              <p>by <a href="https://github.com/GrosSacASac/">Cyril</a> / April 2018</p>
-              <a href="https://github.com/GrosSacASac/JavaScript-Set-Up/tree/master/general/html-streaming"
-                class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://github.com/anton-kabysh/flowtype-experiments" class="image"><img
-                  src="pres_thumb/flow_type_AKa.jpg"
-                  alt="Let your types Flow. Pragmatic introduction to Flowtype" /></a>
-              <h3 class="major">Let your types Flow. Pragmatic introduction to Flowtype</h3>
-              <p>by <a href="https://github.com/anton-kabysh">Anton Kabysh</a> / March 2018</p>
-              <a href="https://github.com/anton-kabysh/flowtype-experiments" class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://docs.google.com/presentation/d/1E8Cz1QX6nLKzG7Vul9bX8hby9u22iT3k2gByCnBHcyM/edit?usp=sharing"
-                class="image"><img src="pres_thumb/ionic_ASp.jpg" alt="IONIC 3 from scratch to store" /></a>
-              <h3 class="major">IONIC 3 from scratch to store</h3>
-              <p>by <a href="https://twitter.com/arthurspitznage?lang=en">Arthur Spitznagel</a> / February 2018</p>
-              <a href="https://docs.google.com/presentation/d/1E8Cz1QX6nLKzG7Vul9bX8hby9u22iT3k2gByCnBHcyM/edit?usp=sharing"
-                class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://github.com/Algar/JSLuxembourg-February2018-VisualRegressionTesting" class="image"><img
-                  src="pres_thumb/visual_regression_AGa.jpg" alt="Visual regression testing" /></a>
-              <h3 class="major">Visual regression testing</h3>
-              <p>by <a href="https://www.yotako.io">Alfonso Garcia</a> / February 2018</p>
-              <a href="https://github.com/Algar/JSLuxembourg-February2018-VisualRegressionTesting"
-                class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://docs.google.com/presentation/d/10dvXKYrEZ_H8MElw6Cdpd4u5COBpJPlquT6Kf2o9iNs/edit?usp=sharing"
-                class="image"><img src="pres_thumb/graphql_TNi.jpg" alt="What the QL? Introduction to GraphQL." /></a>
-              <h3 class="major">What the QL? Introduction to GraphQL.</h3>
-              <p>by <a href="https://twitter.com/littleiffel">Thierry Nicola</a> / January 2018</p>
-              <a href="https://docs.google.com/presentation/d/10dvXKYrEZ_H8MElw6Cdpd4u5COBpJPlquT6Kf2o9iNs/edit?usp=sharing"
-                class="special">Slides</a>
-            </article>
-            <article>
-              <a href="https://js-mf.github.io/" class="image"><img src="pres_thumb/jsmf_JSo.jpg"
-                  alt="The JavaScript Way of Model-Driven Engineering" /></a>
-              <h3 class="major">The JavaScript Way of Model-Driven Engineering</h3>
-              <p>by <a href="https://twitter.com/reversal_js">Jean-Sébastien Sottet</a> / January 2018</p>
-              <a href="https://js-mf.github.io/" class="special">Slides</a>
-            </article>
+            
+              <article>
+                <a href="https://docs.google.com/presentation/d/16_yZG-Z4wuVkluaAuSvo0d4qaJcBcy6BEuSH71JRivY/edit?usp=sharing" class="image">
+                  <img src="pres_thumb/workbox_VSa.png" alt="Creating powerful offline experiences with Workbox" />
+                </a>
+                <h3 class="major">Creating powerful offline experiences with Workbox</h3>
+                <p>by
+                  <a href="https://twitter.com/samvloeberghs">Sam Vloeberghs</a>
+                  / October 2019
+                </p>
+                <a href="https://docs.google.com/presentation/d/16_yZG-Z4wuVkluaAuSvo0d4qaJcBcy6BEuSH71JRivY/edit?usp=sharing" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="http://lekzd.ru/presentations/webgl_simple_luxembourg/" class="image">
+                  <img src="pres_thumb/webgl_AKo.png" alt="WebGL and 2D: simple as Web" />
+                </a>
+                <h3 class="major">WebGL and 2D: simple as Web</h3>
+                <p>by
+                  <a href="https://github.com/lekzd">Aleksandr Korotaev</a>
+                  / June 2019
+                </p>
+                <a href="http://lekzd.ru/presentations/webgl_simple_luxembourg/" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://docs.google.com/presentation/d/1BHJRpiEWq1mIz6uIgV8D2mVGxJ33LNVDHDVT_hwsqx4/edit" class="image">
+                  <img src="pres_thumb/accessibility_in_practice.png" alt="Accessibility in practice" />
+                </a>
+                <h3 class="major">Accessibility in practice</h3>
+                <p>by
+                  <a href="https://twitter.com/pttmary">Marie Baudy</a> & Artur Spulnik
+                  / June 2019
+                </p>
+                <a href="https://docs.google.com/presentation/d/1BHJRpiEWq1mIz6uIgV8D2mVGxJ33LNVDHDVT_hwsqx4/edit" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://github.com/kawan16/nest-heroes/raw/master/Meetup%20Javascript%20Luxembourg%20-%20Nest.pdf" class="image">
+                  <img src="pres_thumb/nest_DKa.png" alt="Nest - A Progressive Node.js Framework" />
+                </a>
+                <h3 class="major">Nest - A Progressive Node.js Framework</h3>
+                <p>by
+                  <a href="https://github.com/kawan16">Karl Devooght</a>
+                  / May 2019
+                </p>
+                <a href="https://github.com/kawan16/nest-heroes/raw/master/Meetup%20Javascript%20Luxembourg%20-%20Nest.pdf" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://www.slideshare.net/CrowChick/vue-in-motion" class="image">
+                  <img src="pres_thumb/vue_in_motion_NRa.png" alt="Vue in Motion" />
+                </a>
+                <h3 class="major">Vue in Motion</h3>
+                <p>by
+                  <a href="http://rachelnabors.com/">Rachel Nabors</a>
+                  / April 2019
+                </p>
+                <a href="https://www.slideshare.net/CrowChick/vue-in-motion" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="pres/intro_vue.pdf" class="image">
+                  <img src="pres_thumb/intro_vue_BSa.png" alt="Intro to Vue.js" />
+                </a>
+                <h3 class="major">Intro to Vue.js</h3>
+                <p>by
+                  Sami Boudrai
+                  / April 2019
+                </p>
+                <a href="pres/intro_vue.pdf" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://stephaniewalter.design/blog/lightning-fast-ux-faking-performance-when-theres-no-code-left-to-optimize/" class="image">
+                  <img src="pres_thumb/lightning_fast_ux_SWa.jpg" alt="Lightning fast UX: faking performance when there’s no code left to optimize" />
+                </a>
+                <h3 class="major">Lightning fast UX: faking performance when there’s no code left to optimize</h3>
+                <p>by
+                  <a href="https://twitter.com/walterstephanie">Stéphanie Walter</a>
+                  / March 2019
+                </p>
+                <a href="https://stephaniewalter.design/blog/lightning-fast-ux-faking-performance-when-theres-no-code-left-to-optimize/" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="pres/webperf_2019.pptx" class="image">
+                  <img src="pres_thumb/web_perf_2019_JEv.png" alt="Web Performance in 2019" />
+                </a>
+                <h3 class="major">Web Performance in 2019</h3>
+                <p>by
+                  <a href="https://twitter.com/theystolemynick">Jean-pierre Vincent</a>
+                  / March 2019
+                </p>
+                <a href="pres/webperf_2019.pptx" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://krampstudio.com/offline-webapp-talk/" class="image">
+                  <img src="pres_thumb/offline-web-app_XYZ.png" alt="Offline Web Apps" />
+                </a>
+                <h3 class="major">Offline Web Apps</h3>
+                <p>by
+                  <a href="https://twitter.com/kramp">Bertrand Chevrier</a>
+                  / February 2019
+                </p>
+                <a href="https://krampstudio.com/offline-webapp-talk/" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://stephaniewalter.design/blog/super-secret-powers-of-mobile-browsers-talk-slides/" class="image">
+                  <img src="pres_thumb/mobile_browsers_SWa.png" alt="Super Secret Powers of Mobile Browsers" />
+                </a>
+                <h3 class="major">Super Secret Powers of Mobile Browsers</h3>
+                <p>by
+                  <a href="https://twitter.com/walterstephanie">Stéphanie Walter</a>
+                  / January 2019
+                </p>
+                <a href="https://stephaniewalter.design/blog/super-secret-powers-of-mobile-browsers-talk-slides/" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://docs.google.com/presentation/d/1HCeTpKv6lCXCGJFtkRFoVbkmd_C5-Ggv4h4JlxHyaXQ/edit#slide=id.g45f10dffa6_0_0" class="image">
+                  <img src="pres_thumb/typescript_GMo.png" alt="Typescript: tips and best practices" />
+                </a>
+                <h3 class="major">Typescript: tips and best practices</h3>
+                <p>by
+                  <a href="https://twitter.com/255kb">Guillaume Monnet</a> & <a href="https://github.com/thomaswinckell">Thomas Winckell</a>
+                  / December 2018
+                </p>
+                <a href="https://docs.google.com/presentation/d/1HCeTpKv6lCXCGJFtkRFoVbkmd_C5-Ggv4h4JlxHyaXQ/edit#slide=id.g45f10dffa6_0_0" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://www.slideshare.net/vasilikaklimova/webgl-practical-application" class="image">
+                  <img src="pres_thumb/webgl_VKl.png" alt="WebGL Practical application" />
+                </a>
+                <h3 class="major">WebGL Practical application</h3>
+                <p>by
+                  <a href="https://twitter.com/lik04ka">Vasilika Klimova</a>
+                  / December 2018
+                </p>
+                <a href="https://www.slideshare.net/vasilikaklimova/webgl-practical-application" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://slides.com/nicolasfrizzarin/angular-element/fullscreen" class="image">
+                  <img src="pres_thumb/angular_element_NFr.png" alt="Angular Element" />
+                </a>
+                <h3 class="major">Angular Element</h3>
+                <p>by
+                  <a href="https://twitter.com/Nicooss54">Nicolas Frizzarin</a>
+                  / November 2018
+                </p>
+                <a href="https://slides.com/nicolasfrizzarin/angular-element/fullscreen" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="pres/devops_SBo.pdf" class="image">
+                  <img src="pres_thumb/devops_SBo.png" alt="Deploy fast and well" />
+                </a>
+                <h3 class="major">Deploy fast and well</h3>
+                <p>by
+                  Sami Boudrai
+                  / November 2018
+                </p>
+                <a href="pres/devops_SBo.pdf" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://docs.google.com/presentation/d/1lhDgVUUWlqhN6ZbWL1Dad0QUwcxPV8zMHp9ssRohZxA/edit?usp=sharing" class="image">
+                  <img src="pres_thumb/mockoon_GUm.png" alt="Mockoon" />
+                </a>
+                <h3 class="major">Mockoon</h3>
+                <p>by
+                  <a href="https://twitter.com/255kb">Guillaume Monnet</a>
+                  / October 2018
+                </p>
+                <a href="https://docs.google.com/presentation/d/1lhDgVUUWlqhN6ZbWL1Dad0QUwcxPV8zMHp9ssRohZxA/edit?usp=sharing" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://becoming.lu/about" class="image">
+                  <img src="pres_thumb/becominglu_ROm.png" alt="Becoming.lu" />
+                </a>
+                <h3 class="major">Becoming.lu</h3>
+                <p>by
+                  <a href="https://bitbucket.org/rodislav">Rodislav Moldovan</a>
+                  / October 2018
+                </p>
+                <a href="https://becoming.lu/about" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://github.com/ffauchille/js-meetup-lu-chatbot" class="image">
+                  <img src="pres_thumb/chatbot_FFa.png" alt="Building chatbots without Cloud" />
+                </a>
+                <h3 class="major">Building chatbots without Cloud</h3>
+                <p>by
+                  <a href="https://github.com/ffauchille">Florent Fauchille</a>
+                  / September 2018
+                </p>
+                <a href="https://github.com/ffauchille/js-meetup-lu-chatbot" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://dom99.now.sh/presentation/reveal.js-2.6.2/test/examples/dom99" class="image">
+                  <img src="pres_thumb/dom99_CWa.png" alt="dom99" />
+                </a>
+                <h3 class="major">dom99</h3>
+                <p>by
+                  <a href="https://github.com/GrosSacASac">Cyril Walle</a>
+                  / September 2018
+                </p>
+                <a href="https://dom99.now.sh/presentation/reveal.js-2.6.2/test/examples/dom99" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://speakerdeck.com/littleiffel/reflections-on-operating-a-serverless-api" class="image">
+                  <img src="pres_thumb/serverless_TNi.jpg" alt="On Serverless - Using Serverless in Production" />
+                </a>
+                <h3 class="major">On Serverless - Using Serverless in Production</h3>
+                <p>by
+                  <a href="https://twitter.com/littleiffel">Thierry Nicola</a>
+                  / June 2018
+                </p>
+                <a href="https://speakerdeck.com/littleiffel/reflections-on-operating-a-serverless-api" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://www.dropbox.com/s/gwayo9hn7vfv2q1/CSS-Variables.pdf?dl=0" class="image">
+                  <img src="pres_thumb/css_variables_GCr.jpg" alt="CSS Variables in the real life" />
+                </a>
+                <h3 class="major">CSS Variables in the real life</h3>
+                <p>by
+                  <a href="https://twitter.com/geoffrey_crofte">Geoffrey Crofte</a>
+                  / May 2018
+                </p>
+                <a href="https://www.dropbox.com/s/gwayo9hn7vfv2q1/CSS-Variables.pdf?dl=0" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://slides.com/alainvagner/deck#/" class="image">
+                  <img src="pres_thumb/accessibility_101_AVa.jpg" alt="Accessibility 101" />
+                </a>
+                <h3 class="major">Accessibility 101</h3>
+                <p>by
+                  <a href="https://twitter.com/biou">Alain Vagner</a>
+                  / May 2018
+                </p>
+                <a href="https://slides.com/alainvagner/deck#/" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://github.com/ou2s/slides/raw/master/JSMeetup%20Luxembourg%20-%2003042018/JSMeetup_RN_in_Production.pdf" class="image">
+                  <img src="pres_thumb/react_native_OGh.jpg" alt="React Native in production" />
+                </a>
+                <h3 class="major">React Native in production</h3>
+                <p>by
+                  <a href="https://github.com/ou2s">Oussama Ghalbzouri</a>
+                  / April 2018
+                </p>
+                <a href="https://github.com/ou2s/slides/raw/master/JSMeetup%20Luxembourg%20-%2003042018/JSMeetup_RN_in_Production.pdf" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://github.com/GrosSacASac/JavaScript-Set-Up/tree/master/general/html-streaming" class="image">
+                  <img src="pres_thumb/html_streaming_CWa.jpg" alt="HTML Streaming" />
+                </a>
+                <h3 class="major">HTML Streaming</h3>
+                <p>by
+                  <a href="https://github.com/GrosSacASac/">Cyril Walle</a>
+                  / April 2018
+                </p>
+                <a href="https://github.com/GrosSacASac/JavaScript-Set-Up/tree/master/general/html-streaming" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://github.com/anton-kabysh/flowtype-experiments" class="image">
+                  <img src="pres_thumb/flow_type_AKa.jpg" alt="Let your types Flow. Pragmatic introduction to Flowtype" />
+                </a>
+                <h3 class="major">Let your types Flow. Pragmatic introduction to Flowtype</h3>
+                <p>by
+                  <a href="https://github.com/anton-kabysh">Anton Kabysh</a>
+                  / March 2018
+                </p>
+                <a href="https://github.com/anton-kabysh/flowtype-experiments" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://docs.google.com/presentation/d/1E8Cz1QX6nLKzG7Vul9bX8hby9u22iT3k2gByCnBHcyM/edit?usp=sharing" class="image">
+                  <img src="pres_thumb/ionic_ASp.jpg" alt="IONIC 3 from scratch to store" />
+                </a>
+                <h3 class="major">IONIC 3 from scratch to store</h3>
+                <p>by
+                  <a href="https://twitter.com/arthurspitznage">Arthur Spitznagel</a>
+                  / February 2018
+                </p>
+                <a href="https://docs.google.com/presentation/d/1E8Cz1QX6nLKzG7Vul9bX8hby9u22iT3k2gByCnBHcyM/edit?usp=sharing" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://github.com/Algar/JSLuxembourg-February2018-VisualRegressionTesting" class="image">
+                  <img src="pres_thumb/visual_regression_AGa.jpg" alt="Visual regression testing" />
+                </a>
+                <h3 class="major">Visual regression testing</h3>
+                <p>by
+                  <a href="https://www.yotako.io">Alfonso Garcia</a>
+                  / February 2018
+                </p>
+                <a href="https://github.com/Algar/JSLuxembourg-February2018-VisualRegressionTesting" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://docs.google.com/presentation/d/10dvXKYrEZ_H8MElw6Cdpd4u5COBpJPlquT6Kf2o9iNs/edit?usp=sharing" class="image">
+                  <img src="pres_thumb/graphql_TNi.jpg" alt="What the QL? Introduction to GraphQL." />
+                </a>
+                <h3 class="major">What the QL? Introduction to GraphQL.</h3>
+                <p>by
+                  <a href="https://twitter.com/littleiffel">Thierry Nicola</a>
+                  / January 2018
+                </p>
+                <a href="https://docs.google.com/presentation/d/10dvXKYrEZ_H8MElw6Cdpd4u5COBpJPlquT6Kf2o9iNs/edit?usp=sharing" class="special">Slides</a>
+              </article>
+            
+              <article>
+                <a href="https://js-mf.github.io/" class="image">
+                  <img src="pres_thumb/jsmf_JSo.jpg" alt="The JavaScript Way of Model-Driven Engineering" />
+                </a>
+                <h3 class="major">The JavaScript Way of Model-Driven Engineering</h3>
+                <p>by
+                  <a href="https://twitter.com/reversal_js">Jean-Sébastien Sottet</a>
+                  / January 2018
+                </p>
+                <a href="https://js-mf.github.io/" class="special">Slides</a>
+              </article>
+            
           </section>
         </div>
       </section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,131 @@
+{
+  "name": "luxembourgjs.com",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "ejs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.2.tgz",
+      "integrity": "sha512-zFuywxrAWtX5Mk2KAuoJNkXXbfezpNA0v7i+YC971QORguPekpjpAgeOv99YWSdKXwj7JxI2QAWDeDkE8fWtXw==",
+      "dev": true,
+      "requires": {
+        "jake": "^10.6.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "filelist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz",
+      "integrity": "sha512-8zSK6Nu0DQIC08mUC46sWGXi+q3GGpKydAG36k+JDba6VRpkevvOWUW5a/PhShij4+vHT9M+ghgG7eM+a9JDUQ==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "jake": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.6.1.tgz",
+      "integrity": "sha512-pHUK3+V0BjOb1XSi95rbBksrMdIqLVC9bJqDnshVyleYsET3H0XAq+3VB2E3notcYvv4wRdRHn13p7vobG+wfQ==",
+      "dev": true,
+      "requires": {
+        "async": "0.9.x",
+        "chalk": "^2.4.2",
+        "filelist": "^1.0.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "luxembourgjs.com",
+  "description": "This is the source code of the website **luxembourgjs.com**",
+  "keywords": [
+    "luxembourgjs",
+    "luxembourg",
+    "javascript",
+    "meetup"
+  ],
+  "version": "0.0.1",
+  "scripts": {
+    "build": "node ./build.js"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "ejs": "^3.1.2"
+  }
+}


### PR DESCRIPTION
Instead of writing redundant HTML code for slides, data is now stored in a JSON file (`data/pres-data.json`) and rendering is done using EJS. We now have an `index.ejs.html` that is the EJS template that generates an `index.html`.

To add slides, we now have to :
- add slides to the JSON file `data/pres-data.json`
- `npm run build` (`npm install before`)
- make a pull request (or push to master if you have the rights)

Feel free to challenge this solution. I find this simple and better than the messy HTML file.